### PR TITLE
fix: remove unit before passing chunk to powerbox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
     { name = "James Davies", email = "james.davies@sns.it" },
     { name = "Steven Murray", email = "murray.steveng@gmail.com" },
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 license = {text="MIT"}
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/src/tuesday/core/summaries/powerspectra.py
+++ b/src/tuesday/core/summaries/powerspectra.py
@@ -185,7 +185,7 @@ def calculate_ps(
     ps1d = None
     if calc_2d:
         results = get_power(
-            chunk,
+            chunk.value,
             (
                 box_length.value,
                 box_length.value,

--- a/tests/test_ps.py
+++ b/tests/test_ps.py
@@ -82,7 +82,7 @@ def test_calculate_ps_errors(test_lc):
 @pytest.mark.parametrize("log_bins", [True, False])
 def test_calculate_ps_lc(log_bins, test_lc, test_redshifts):
     calculate_ps_lc(
-        test_lc * un.dimensionless_unscaled,
+        test_lc * un.mK,
         200 * un.Mpc,
         test_redshifts,
         ps_redshifts=[6.0],
@@ -126,7 +126,7 @@ def test_calculate_ps_lc(log_bins, test_lc, test_redshifts):
 def test_calculate_ps_coeval(test_coeval):
     with np.testing.assert_raises(TypeError):
         calculate_ps_coeval(
-            test_coeval * un.dimensionless_unscaled,
+            test_coeval * un.mK,
             box_length=200 * un.Mpc,
             ps_redshifts=6.8,
             calc_1d=False,


### PR DESCRIPTION
Fix bug that occurs with numpy >= 2.2