### PR TITLE
Fix 2 wedge removal bugs: Unnecessary Fourier shifting and only removing positive k_parallel

### DIFF
--- a/src/tuesday/core/instrument_models/noise.py
+++ b/src/tuesday/core/instrument_models/noise.py
@@ -415,10 +415,7 @@ def apply_wedge_filter(
 
         uvtau = np.fft.fft(uv_chunk, axis=-1)
         this_dnu = np.mean(np.diff(freqs_chunk))
-        tau = (
-                np.fft.fftfreq(uv_chunk.shape[-1], d=this_dnu.to(un.Hz).value)
-            * un.s
-        )
+        tau = np.fft.fftfreq(uv_chunk.shape[-1], d=this_dnu.to(un.Hz).value) * un.s
 
         kperp_mag = np.add.outer(kperp_grid**2, kperp_grid**2) ** 0.5
         umag = kperp_mag / dk_du(f2z(f0), with_h=with_h)


### PR DESCRIPTION
Wedge removal now: 
<img width="1066" height="511" alt="download" src="https://github.com/user-attachments/assets/ca4acf5e-cc4d-4de0-b23e-38aa2b0ed184" />
Wedge removal before:
<img width="1069" height="511" alt="image" src="https://github.com/user-attachments/assets/4dd6cdcd-2c70-4720-89e2-8267a75eceb1" />
